### PR TITLE
Monitoring core ML models with Fritz's SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,66 @@
+# Xcode
+# From https://www.stuartbreckenridge.com/default-gitignore/
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+
+## Other
+*.xccheckout
+*.moved-aside
+*.xcuserstate
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the 
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://github.com/fastlane/fastlane/blob/master/docs/Gitignore.md
+
+fastlane/report.xml
+fastlane/screenshots
+
+.DS_Store

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,11 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'ShowAndTell' do
+  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for ShowAndTell
+  pod 'Fritz', '~> 1.0.0-beta'
+
+end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,12 @@
+PODS:
+  - Fritz (1.0.0-beta5)
+
+DEPENDENCIES:
+  - Fritz (~> 1.0.0-beta)
+
+SPEC CHECKSUMS:
+  Fritz: a3bf484ce949e36748f1b365049be9e5b21a91c9
+
+PODFILE CHECKSUM: fe90b7a071b4ffc8cfd927f7d1983c0ddb7e66e3
+
+COCOAPODS: 1.4.0

--- a/ShowAndTell.xcodeproj/project.pbxproj
+++ b/ShowAndTell.xcodeproj/project.pbxproj
@@ -61,6 +61,9 @@
 		5684D7D41FD78BA200CA4F0E /* COCO_train2014_000000005505.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 5684D7A71FD78A0100CA4F0E /* COCO_train2014_000000005505.jpg */; };
 		56A562DC1FDE2CE20032B8F1 /* ShowAndTell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A562DB1FDE2CE20032B8F1 /* ShowAndTell.swift */; };
 		56A562E01FDE30CF0032B8F1 /* GSMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A562DF1FDE30CF0032B8F1 /* GSMessage.swift */; };
+		5F3831C42028F03600C9C82A /* keras_inception_step_good_without_label+Fritz.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3831C32028F03600C9C82A /* keras_inception_step_good_without_label+Fritz.swift */; };
+		5F3831C62028F05700C9C82A /* keras_inception_lstm_good+Fritz.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3831C52028F05700C9C82A /* keras_inception_lstm_good+Fritz.swift */; };
+		9D24D93267283B6B2B996CBD /* Pods_ShowAndTell.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B216E824CF4A734ED05EE458 /* Pods_ShowAndTell.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -120,6 +123,11 @@
 		5684D7B11FD78A0300CA4F0E /* COCO_train2014_000000005469.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = COCO_train2014_000000005469.jpg; sourceTree = "<group>"; };
 		56A562DB1FDE2CE20032B8F1 /* ShowAndTell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowAndTell.swift; sourceTree = "<group>"; };
 		56A562DF1FDE30CF0032B8F1 /* GSMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSMessage.swift; sourceTree = "<group>"; };
+		5F3831C32028F03600C9C82A /* keras_inception_step_good_without_label+Fritz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "keras_inception_step_good_without_label+Fritz.swift"; sourceTree = "<group>"; };
+		5F3831C52028F05700C9C82A /* keras_inception_lstm_good+Fritz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "keras_inception_lstm_good+Fritz.swift"; sourceTree = "<group>"; };
+		A97B2B296B626E696DFF4E10 /* Pods-ShowAndTell.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ShowAndTell.release.xcconfig"; path = "Pods/Target Support Files/Pods-ShowAndTell/Pods-ShowAndTell.release.xcconfig"; sourceTree = "<group>"; };
+		B216E824CF4A734ED05EE458 /* Pods_ShowAndTell.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ShowAndTell.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E36C5AA1DF0504633FDCAA15 /* Pods-ShowAndTell.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ShowAndTell.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ShowAndTell/Pods-ShowAndTell.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +135,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9D24D93267283B6B2B996CBD /* Pods_ShowAndTell.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -138,6 +147,8 @@
 			children = (
 				5650753C1FD695330070573D /* ShowAndTell */,
 				5650753B1FD695330070573D /* Products */,
+				AAA6108DB3A334DD5A1E1A0A /* Pods */,
+				F7A6FA7EF746ECFD29A77C60 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -179,6 +190,8 @@
 				5684D77B1FD6DC4700CA4F0E /* NonMaxSuppression.swift */,
 				5684D77C1FD6DC4700CA4F0E /* Predictions.swift */,
 				5684D77D1FD6DC4700CA4F0E /* UIImage+CVPixelBuffer.swift */,
+				5F3831C32028F03600C9C82A /* keras_inception_step_good_without_label+Fritz.swift */,
+				5F3831C52028F05700C9C82A /* keras_inception_lstm_good+Fritz.swift */,
 			);
 			path = CoreMLHelpers;
 			sourceTree = "<group>";
@@ -235,6 +248,23 @@
 			path = ShowAndTell;
 			sourceTree = "<group>";
 		};
+		AAA6108DB3A334DD5A1E1A0A /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				E36C5AA1DF0504633FDCAA15 /* Pods-ShowAndTell.debug.xcconfig */,
+				A97B2B296B626E696DFF4E10 /* Pods-ShowAndTell.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		F7A6FA7EF746ECFD29A77C60 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				B216E824CF4A734ED05EE458 /* Pods_ShowAndTell.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -242,9 +272,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5650754C1FD695330070573D /* Build configuration list for PBXNativeTarget "ShowAndTell" */;
 			buildPhases = (
+				C6D52B0044FF911528169116 /* [CP] Check Pods Manifest.lock */,
 				565075361FD695330070573D /* Sources */,
 				565075371FD695330070573D /* Frameworks */,
 				565075381FD695330070573D /* Resources */,
+				3EBC71879BB65FF5F0647C65 /* [CP] Embed Pods Frameworks */,
+				F228ECC26B3D1A1E9D64D9C4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -338,11 +371,66 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		3EBC71879BB65FF5F0647C65 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-ShowAndTell/Pods-ShowAndTell-frameworks.sh",
+				"${PODS_ROOT}/Fritz/Framework/Fritz.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Fritz.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ShowAndTell/Pods-ShowAndTell-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C6D52B0044FF911528169116 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ShowAndTell-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F228ECC26B3D1A1E9D64D9C4 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ShowAndTell/Pods-ShowAndTell-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		565075361FD695330070573D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5F3831C62028F05700C9C82A /* keras_inception_lstm_good+Fritz.swift in Sources */,
 				5684D77E1FD6DC5400CA4F0E /* Array.swift in Sources */,
 				56A562DC1FDE2CE20032B8F1 /* ShowAndTell.swift in Sources */,
 				5684D77F1FD6DC5400CA4F0E /* CVPixelBuffer+Helpers.swift in Sources */,
@@ -354,6 +442,7 @@
 				5684D7831FD6DC5400CA4F0E /* NonMaxSuppression.swift in Sources */,
 				5684D7841FD6DC5400CA4F0E /* Predictions.swift in Sources */,
 				5608A2E71FDC2FB500118D59 /* keras_inception_step_good_without_label.mlmodel in Sources */,
+				5F3831C42028F03600C9C82A /* keras_inception_step_good_without_label+Fritz.swift in Sources */,
 				56A562E01FDE30CF0032B8F1 /* GSMessage.swift in Sources */,
 				5684D7851FD6DC5400CA4F0E /* UIImage+CVPixelBuffer.swift in Sources */,
 				565075401FD695330070573D /* ViewController.swift in Sources */,
@@ -492,6 +581,7 @@
 		};
 		5650754D1FD695330070573D /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E36C5AA1DF0504633FDCAA15 /* Pods-ShowAndTell.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -507,6 +597,7 @@
 		};
 		5650754E1FD695330070573D /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A97B2B296B626E696DFF4E10 /* Pods-ShowAndTell.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;

--- a/ShowAndTell.xcworkspace/contents.xcworkspacedata
+++ b/ShowAndTell.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:ShowAndTell.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ShowAndTell/CoreMLHelpers/keras_inception_lstm_good+Fritz.swift
+++ b/ShowAndTell/CoreMLHelpers/keras_inception_lstm_good+Fritz.swift
@@ -1,0 +1,15 @@
+//
+//  keras_inception_lstm_good+Fritz.swift
+//  ShowAndTell
+//
+
+import Fritz
+
+extension keras_inception_lstm_good: SwiftIdentifiedModel {
+
+    static let modelIdentifier = "<insert model id>"
+
+    static let packagedModelVersion = 1
+
+    static let session = Session(appToken: "<insert app token>")
+}

--- a/ShowAndTell/CoreMLHelpers/keras_inception_step_good_without_label+Fritz.swift
+++ b/ShowAndTell/CoreMLHelpers/keras_inception_step_good_without_label+Fritz.swift
@@ -1,0 +1,15 @@
+//
+//  keras_inception_step_good_without_label+Fritz.swift
+//  ShowAndTell
+//
+
+import Fritz
+
+extension keras_inception_step_good_without_label: SwiftIdentifiedModel {
+
+    static let modelIdentifier = "<insert model id>"
+
+    static let packagedModelVersion = 1
+
+    static let session = Session(appToken: "<insert app token>")
+}

--- a/ShowAndTell/ShowAndTell/ShowAndTell.swift
+++ b/ShowAndTell/ShowAndTell/ShowAndTell.swift
@@ -11,8 +11,8 @@ import UIKit
 import CoreML
 
 // Initialize CoreML models once
-let inception = keras_inception_lstm_good()
-let inceptionWOLabel = keras_inception_step_good_without_label()
+let inception = keras_inception_lstm_good().fritz()
+let inceptionWOLabel = keras_inception_step_good_without_label().fritz()
 
 class ShowAndTell {
     let wordDict: [String]

--- a/ShowAndTell/ShowAndTell/ShowAndTell.swift
+++ b/ShowAndTell/ShowAndTell/ShowAndTell.swift
@@ -10,6 +10,10 @@ import Foundation
 import UIKit
 import CoreML
 
+// Initialize CoreML models once
+let inception = keras_inception_lstm_good()
+let inceptionWOLabel = keras_inception_step_good_without_label()
+
 class ShowAndTell {
     let wordDict: [String]
     required init() {
@@ -34,7 +38,7 @@ class ShowAndTell {
     func predict(image: UIImage, beamSize: Int = 3, maxWordNumber:Int = 20) -> PriorityQueue<Caption> {
         let img = image.pixelBuffer(width: 299, height: 299)!
         // 获取图像感知状态
-        let result = try! keras_inception_lstm_good().prediction(image: img, lstm_1_h_in: nil, lstm_1_c_in: nil)
+        let result = try! inception.prediction(image: img, lstm_1_h_in: nil, lstm_1_c_in: nil)
         
         let initialCaption = Caption(state: (result.lstm_1_h_out, result.lstm_1_c_out))
         
@@ -118,7 +122,7 @@ class Caption: Comparable {
     }
     
     func nextStepWith(beamSize: Int, vocabDict: [String]) -> [Caption] {
-        let result = try! keras_inception_step_good_without_label().prediction(input1: self.lastWordMatrix(), lstm_1_h_in: self.state.0, lstm_1_c_in: self.state.1)
+        let result = try! inceptionWOLabel.prediction(input1: self.lastWordMatrix(), lstm_1_h_in: self.state.0, lstm_1_c_in: self.state.1)
         
         let topK = PriorityQueue<Word>(maxLength: beamSize, compare: {$0 > $1})
         


### PR DESCRIPTION
Awesome work with the ShowAndTell project! Love the fact that you converted it into core ML.

I noticed a couple of small things which might help like initializing the model once at the start of the app instead of each time it’s invoked. I also took the liberty to add Fritz, a platform to optimize, monitor, and deploy Core ML models on mobile.  It’s a simple SDK that I brought in using Cocoapods. Full transparency, I’m leading a team at Fritz and trying to gather some feedback from mobile machine learning experts like yourself.

After initializing it, I was able to pull in some metrics on your model execution at http://fritz.ai. Check out that site and I'd be happy to give you access.

![show-and-tell-vid](https://user-images.githubusercontent.com/31963796/35826420-b14dc0ac-0a86-11e8-81d0-66704ad03544.gif)
